### PR TITLE
Display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This page will explain how to fix a number of issues with the latest **Ubuntu 19
 - CPU power management
 - Changing brightness of OLED screen with brightness keys
 - Enabling hardware acceleration for video decoding in Chrome
+- Keyboard backlight
 
 ## Installation
 
@@ -94,3 +95,12 @@ sudo apt update
 sudo apt install chromium-browser
 ```
 For more details and instructions on possibly required driver updates see [here](https://www.linuxuprising.com/2018/08/how-to-enable-hardware-accelerated.html).
+
+## Keyboard backlight
+Keyboard backlight can be properly enable changing in `/etc/default/grub` then GRUB_CMDLINE_LINUX_DEFAULT setting to:
+
+    GRUB_CMDLINE_LINUX_DEFAULT="quiet splash acpi_osi"
+
+Adding `acpi_osi=` instructs the kernel to reply with an empty string (instead of 'Linux') when the BIOS queries about the running OS.
+
+Remember to run `sudo update-grub; sudo reboot` to make the changes effective.

--- a/README.md
+++ b/README.md
@@ -97,10 +97,4 @@ sudo apt install chromium-browser
 For more details and instructions on possibly required driver updates see [here](https://www.linuxuprising.com/2018/08/how-to-enable-hardware-accelerated.html).
 
 ## Keyboard backlight
-Keyboard backlight can be properly enable changing in `/etc/default/grub` then GRUB_CMDLINE_LINUX_DEFAULT setting to:
-
-    GRUB_CMDLINE_LINUX_DEFAULT="quiet splash acpi_osi"
-
-Adding `acpi_osi=` instructs the kernel to reply with an empty string (instead of 'Linux') when the BIOS queries about the running OS.
-
-Remember to run `sudo update-grub; sudo reboot` to make the changes effective.
+Keyboard backlight should work out of the box with BIOS 1.3.3

--- a/dell-brightness.sh
+++ b/dell-brightness.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 export XAUTHORITY=/run/user/1000/gdm/Xauthority 
 export DISPLAY=:0.0
-DISPLAYNAME=eDP-1
+DISPLAYNAME=$(xrandr --listmonitors | awk '$1 == "0:" {print $4}')
 
 OLED_BR=`xrandr --verbose | grep -i brightness | cut -f2 -d ' '`
 CURR=`LC_ALL=C /usr/bin/printf "%.*f" 1 $OLED_BR`


### PR DESCRIPTION
Query for display nameYou can query for the display name sing

    xrandr --listmonitors | awk '$1 == "0:" {print $4}'


https://github.com/TillmannBerg/Ubuntu-Dell-XPS-15-2019/blob/85c988bdc6df1df23f1df801bd98e21b3c555674/dell-brightness.sh#L4