### PR TITLE
Remove XAUTHORITY and DISPLAY variables

### DIFF
--- a/dell-brightness.sh
+++ b/dell-brightness.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-export XAUTHORITY=/run/user/1000/gdm/Xauthority 
-export DISPLAY=:0.0
 DISPLAYNAME=eDP-1
 
 OLED_BR=`xrandr --verbose | grep -i brightness | cut -f2 -d ' '`


### PR DESCRIPTION
Exporting them caused `xrandr` to not work properly. With this change the script works as expected